### PR TITLE
fix a bug that javascript can not be commented by //

### DIFF
--- a/plugin/comments.vim
+++ b/plugin/comments.vim
@@ -100,7 +100,7 @@ if !exists('g:comments_map_keys')
     let g:comments_map_keys = 1
 endif
 
-if g:comments_map_keys = 1
+if g:comments_map_keys
     " key-mappings for comment line in normal mode
     noremap  <silent> <C-C> :call CommentLine()<CR>
     " key-mappings for range comment lines in visual <Shift-V> mode


### PR DESCRIPTION
really be commented

```
    //alert("xx")  
```

not really be commented, still alerting

```
    /*alert("xx")*/
```

and since // works fine, and it will block the chain for the shortcut key going into the next condition(/**/), so I think it could be removed.
