### PR TITLE
added support for jsx and ts file extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,26 @@
-comments.vim
-=============
+# comments.vim
 
-Global Plugin to comment and un-comment lines in different source files in both normal and visual <Shift-V> mode 
+Global Plugin to comment and un-comment lines in different source files in both normal and visual <Shift-V> mode
 
 The following are the changes that I have done to the original Plugin
 
+- Added support for React (.jsx) and TypeScript (.ts)
 - Added support for Arduino files (both .pde and .ino)
 - Added support for Pig files (.pig)
 - Added support for Golang (.go) (by [Athom](https://github.com/athom))
 - Added support for remapping the keys if needed
 - Added support for Clojure and ClojureScript (by [seedano](https://github.com/ssedano/))
-- Added support for Matlab and Octave (*.m) files
+- Added support for Matlab and Octave (\*.m) files
 
 Credit goes to the original author Jasmeet Singh Anand.
 
-Installation
-============
+# Installation
 
-Manual 
-------
+## Manual
+
 Stick this file in your ~/.vim/plugin directory or in some other 'plugin' directory that is in your runtime path
 
-Using [Vundle](https://github.com/gmarik/vundle)
--------------
+## Using [Vundle](https://github.com/gmarik/vundle)
 
 ```VimL
 
@@ -32,8 +30,7 @@ Using [Vundle](https://github.com/gmarik/vundle)
 
 ```
 
-Configuration
-=============
+# Configuration
 
 By default, the following keys are mapped
 
@@ -59,9 +56,8 @@ You can map your own keys if needed
 
 ```
 
+# Original Readme file
 
-Original Readme file
-====================
 This is a mirror of http://www.vim.org/scripts/script.php?script_id=1528
 
 Global Plugin to comment and un-comment lines in different source files in both normal and visual <Shift-V> mode

--- a/plugin/comments.vim
+++ b/plugin/comments.vim
@@ -20,6 +20,9 @@
 " *********************************************************************************************
  "Modification:
 " *********************************************************************************************
+"  Kashaan Mahmood (https://github.com/Kashaan-M/) 20th January, 2023
+"  Added support for React JSX (*.jsx) and TypeScript (*.ts) files
+" *********************************************************************************************
 " Sudar Muthu (http://sudarmuthu.com) 28th November, 2012 
 " Added support for Matlab and Octave (*.m) files
 " *********************************************************************************************
@@ -124,8 +127,8 @@ endif
 function! CommentLine()
   let file_name = buffer_name("%")
 
-  " for .cpp or .hpp or .java or .js or arduino (*.ino or *.pde) or go files use //
-  if file_name =~ '\.cpp$' || file_name =~ '\.hpp$' || file_name =~ '\.java$' || file_name =~ '\.php[2345]\?$' || file_name =~ '\.C$' || file_name =~ '\.ino$' || file_name =~ '\.pde$' || file_name =~ '\.go$' || file_name =~ '\.js$' 
+  " for .cpp or .hpp or .java or .js or .ts or arduino (*.ino or *.pde) or go files use //
+  if file_name =~ '\.cpp$' || file_name =~ '\.hpp$' || file_name =~ '\.java$' || file_name =~ '\.php[2345]\?$' || file_name =~ '\.C$' || file_name =~ '\.ino$' || file_name =~ '\.pde$' || file_name =~ '\.go$' || file_name =~ '\.js$' || file_name =~ '\.ts$' 
     execute ":silent! normal ^i//\<ESC>==\<down>^"
   " for .c or .h or .pc or .css files use /* */
   elseif file_name =~ '\.c$' || file_name =~ '\.h$' || file_name =~ '\.pc$' || file_name =~ '\.css$'
@@ -182,6 +185,12 @@ function! CommentLine()
   " for .clj or .cljs files use ;
   elseif file_name =~ '\.clj$' || file_name =~ '\.cljs$'
     execute ":silent! normal ^i;; \<ESC>\<down>"
+  " for .jsx
+  elseif file_name=~ '\.jsx$'
+    execute ":silent! normal ^i{\/\*\<ESC>$a\*\/}\<ESC>==\<down>^"
+    " there is a small bug when the a line in .jsx starts with <, we see an additional } pop up to the left side.
+    " The below execute solves that but I don't know enough vimscript to solve this bug
+    " execute ":silent! normal ^i{\/\*\<ESC>\<right>i\<BS>\<ESC>$a\*\/}\<ESC>==\<down>^"
   " for all other files use # 
   else
     execute ":silent! normal ^i#\<ESC>\<down>^"
@@ -193,7 +202,7 @@ function! UnCommentLine()
   let file_name = buffer_name("%")
 
   " for .cpp or .hpp or .java or .js or arduino (*.ino or *.pde) files use //
-  if file_name =~ '\.cpp$' || file_name =~ '\.hpp$' || file_name =~ '\.java$' || file_name =~ '\.php[2345]\?$' || file_name =~ '\.C$' || file_name =~ '\.ino$' || file_name =~ '\.pde$' || file_name =~ '\.go$' || file_name =~ '\.js$' 
+  if file_name =~ '\.cpp$' || file_name =~ '\.hpp$' || file_name =~ '\.java$' || file_name =~ '\.php[2345]\?$' || file_name =~ '\.C$' || file_name =~ '\.ino$' || file_name =~ '\.pde$' || file_name =~ '\.go$' || file_name =~ '\.js$' || file_name =~ '\.ts$'
     execute ":silent! normal :nohlsearch\<CR>:s/\\/\\///\<CR>:nohlsearch\<CR>=="
   " for .ml or .mli
   elseif file_name =~ '\.ml$' || file_name =~ '\.mli$'
@@ -230,6 +239,10 @@ function! UnCommentLine()
   " for .clj or .cljs
   elseif file_name =~ '\.clj$' || file_name =~ '\.cljs$'
       execute ":silent! normal :nohlsearch\<CR>:s/;; //\<CR>:nohlsearch\<CR>=="
+  " for .jsx 
+  elseif file_name =~ '\.jsx$'
+      execute ":silent! normal :nohlsearch\<CR>:s/{\\/\\*//\<CR>=="
+      execute ":silent! normal :nohlsearch\<CR>:s/\\*\\/}//\<CR>=="
   " for all other files use # 
   else
     execute ":silent! normal :nohlsearch\<CR>:s/\\#//\<CR>:nohlsearch\<CR>"


### PR DESCRIPTION
Hi Mr.Sudar Muthu,
I am using your comments.vim plugin and I like it and am thankful to all who have contributed to it.
I am using this to work with JSX and TypeScript (occasionally) and I added comments support for these file extensions. There is a small bug in JSX but I am satisfied with what the plugin delivers. 
Thanks for reading,
Kashaan